### PR TITLE
Make calls to native os functions instead of system

### DIFF
--- a/photon.py
+++ b/photon.py
@@ -324,8 +324,8 @@ flash(jscanner, scripts)
 
 # Step 4. Save the results
 if os.path.exists(name):
-    os.system('rm -r %s' % name)
-os.system('mkdir %s' % name)
+    os.rmdir(name)
+os.mkdir(name)
 
 with open('%s/links.txt' % name, 'w+') as f:
     for x in storage:


### PR DESCRIPTION
This will increase compatibility (for example on iOS, which doesn't
have os.system)

Are there any downsides to using the native functions? I don’t think so but you’re more experienced than me and may have a reason to still use os.system 