### PR TITLE
Undefined name: seeds --> args.seeds

### DIFF
--- a/photon.py
+++ b/photon.py
@@ -440,7 +440,7 @@ for level in range(crawl_level):
     if not links: # if links to crawl are 0 i.e. all links have been crawled
         break
     elif len(storage) <= len(processed): # if crawled links are somehow more than all links. Possible? ;/
-        if len(storage) > 2 + len(seeds): # if you know it, you know it
+        if len(storage) > 2 + len(args.seeds): # if you know it, you know it
             break
     print ('%s Level %i: %i URLs' % (run, level + 1, len(links)))
     try:


### PR DESCRIPTION
__seeds__ is an undefined name in this context so replace it with __args.seeds__ which is used on line 149.

flake8 testing of https://github.com/s0md3v/Photon on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./photon.py:19:13: F821 undefined name 'raw_input'
    input = raw_input
            ^
./photon.py:443:35: F821 undefined name 'seeds'
        if len(storage) > 2 + len(seeds): # if you know it, you know it
                                  ^
2     F821 undefined name 'raw_input'
2
```