### PR TITLE
Travis CI: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
-install:
-  - pip install -r requirements.txt
 os:
   - linux
 python:
-    - 2.7
-    - 3.6
+  - 2.7
+  - 3.6
+install:
+  - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - python photon.py -u "https://stackoverflow.com" -l 1 -d 1 -t 100 --regex "\d{10}" --dns --output="d3v"
   - python photon.py -u "https://stackoverflow.com" -l 1 -t 10 --seeds="https://stackoverflow.com/jobs" --only-urls --export=json

--- a/photon.py
+++ b/photon.py
@@ -16,9 +16,13 @@ try:
     from urllib.parse import urlparse # for python3
     python2, python3 = False, True
 except ImportError:
-    input = raw_input
     from urlparse import urlparse # for python2
     python2, python3 = True, False
+
+try:
+    input = raw_input
+except NameError:
+    pass
 
 colors = True # Output should be colored
 machine = sys.platform # Detecting the os of current system


### PR DESCRIPTION
Add http://flake8.pycqa.org tests to look for Python syntax errors and undefined names

E901,E999,F821,F822,F823 are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

    F821: undefined name name
    F822: undefined name name in __all__
    F823: local variable name referenced before assignment
    E901: SyntaxError or IndentationError
    E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree