### PR TITLE
Fix random chooser's accessability to support NoneTypes and update host for the http headers

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -16,8 +16,8 @@ def requester(
         headers=None,
         timeout=10,
         host=None,
-        proxies=None,
-        user_agents=None,
+        proxies=[None],
+        user_agents=[None],
         failed=None,
         processed=None
     ):

--- a/core/updater.py
+++ b/core/updater.py
@@ -13,7 +13,7 @@ def updater():
     print('%s Checking for updates' % run)
     # Changes must be separated by ;
     changes = '''major bug fixes;removed ninja mode;dropped python < 3.2 support;fixed unicode output;proxy support;more intels'''
-    latest_commit = requester('https://raw.githubusercontent.com/s0md3v/Photon/master/core/updater.py', host='github.com')
+    latest_commit = requester('https://raw.githubusercontent.com/s0md3v/Photon/master/core/updater.py', host='raw.githubusercontent.com')
     # Just a hack to see if a new version is available
     if changes not in latest_commit:
         changelog = re.search(r"changes = '''(.*?)'''", latest_commit)


### PR DESCRIPTION
1. Host and url for the update request hack were not compitable as by the actual HTTP request header for the host

2. when calling requester with defaults (by updater), random chooser cannot support NoneType, not in the suited dict object aswell. now user agents and proxies which are used for the rand, are listed for NoneTypes, which enables him to choose.
