### PR TITLE
Fix for regex at dnsdumper

### DIFF
--- a/plugins/dnsdumpster.py
+++ b/plugins/dnsdumpster.py
@@ -8,7 +8,7 @@ def dnsdumpster(domain, output_dir):
     """Query dnsdumpster.com."""
     response = requests.Session().get('https://dnsdumpster.com/').text
     csrf_token = re.search(
-        r"name='csrfmiddlewaretoken' value='(.*?)'", response).group(1)
+        r'name="csrfmiddlewaretoken" value="(.*?)", response).group(1)
 
     cookies = {'csrftoken': csrf_token}
     headers = {'Referer': 'https://dnsdumpster.com/'}


### PR DESCRIPTION
The issue was being cause by a never-catcheable regex.

dnsdumpster HTML attributes use double quotes whereas this regex
was catching only the expression with simple ones and thus creating
an empty regex object (None Type).