### PR TITLE
Fix domain extraction when --dns flag is used

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -139,11 +139,9 @@ def extract_headers(headers):
 
 def top_level(url, fix_protocol=True):
     """Extract the top level domain from an URL."""
-    ext = tld.get_tld(url, fix_protocol=fix_protocol)
-    toplevel = '.'.join(urlparse(url).netloc.split('.')[-2:]).split(
-        ext)[0] + ext
+    res = tld.get_tld(url, fix_protocol=fix_protocol, as_object=True)
+    toplevel = res.domain + '.' + res.tld
     return toplevel
-
 
 def is_proxy_list(v, proxies):
     if os.path.isfile(v):

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,19 @@
+import pytest
+import tld.exceptions
+from core.utils import top_level
+
+def test_top_level_with_https_url():
+    assert top_level('https://google.co.uk') == 'google.co.uk'
+    assert top_level('https://google.com') == 'google.com'
+
+def test_top_level_with_one_level_domain():
+    assert top_level('google.co.uk') == 'google.co.uk'
+    assert top_level('google.com') == 'google.com'
+
+def test_top_level_with_second_level_domain():
+    assert top_level('123.google.co.uk') == 'google.co.uk'
+    assert top_level('123.google.com') == 'google.com'
+
+def test_top_level_with_wrong_domain():
+    with pytest.raises(tld.exceptions.TldDomainNotFound):
+        top_level('google.co.uk2')


### PR DESCRIPTION
## Description
* function top_level failed on domains like `co.uk`
* see more info https://en.wikipedia.org/wiki/Second-level_domain
* as a result, the tool generated DNS map for a second-level domain (e.g. co.uk)

### Examples of failure

## Tested on
os: MacOS 10.14.4
python: 3.7.3

## Dependencies
`pytest` for running unit tests (development only)