### PR TITLE
Fix --clone option

### DIFF
--- a/core/mirror.py
+++ b/core/mirror.py
@@ -35,5 +35,5 @@ def mirror(url, response):
             name = webpage
         if len(url.split('?')) > 1:
             trail += '?' + url.split('?')[1]
-        with open(path + name + trail, 'w+') as out_file:
+        with open(path + name + trail, 'wb+') as out_file:
             out_file.write(response.encode('utf-8'))


### PR DESCRIPTION
This stops the `--clone` option from being completely useless due to it stopping the program from crawling anything else (#159)